### PR TITLE
Remove doc URL from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0"
 keywords = ["robotics", "urdf", "visualization"]
 categories = ["visualization"]
 repository = "https://github.com/openrr/urdf-viz"
-documentation = "http://docs.rs/urdf-viz"
 exclude = [".github/*", "img/*"]
 edition = "2018"
 


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#the-documentation-field

> If no URL is specified in the manifest file, crates.io will
> automatically link your crate to the corresponding docs.rs page.